### PR TITLE
Keep the case of the passed-in values

### DIFF
--- a/lib/HTTP/AcceptCharset.pm
+++ b/lib/HTTP/AcceptCharset.pm
@@ -14,22 +14,22 @@ sub match {
     my ($self, @values_to_check) = @_;
 
     @values_to_check =
-        map{ lc $_ }
+        map{ [ $_, lc $_ ] }
         grep{ defined $_ && length $_ }
         @values_to_check;
 
     return '' if !@values_to_check;
 
     my @charsets = @{ $self->values || [] };
-    return $values_to_check[0] if !@charsets;
-
+    return $values_to_check[0][0] if !@charsets;
 
     CHARSET:
     for my $charset ( @charsets ) {
-        return $values_to_check[0] if $charset eq '*';
+        return $values_to_check[0][0] if $charset eq '*';
 
-        my $found = first { $_ eq $charset }@values_to_check;
-        return $found if $found;
+        my $c = lc $charset;
+        my $found = first { $_->[1] eq $c } @values_to_check;
+        return $found->[0] if $found;
     }
 
     return '';

--- a/t/base.t
+++ b/t/base.t
@@ -107,6 +107,26 @@ my %tests = (
             ],
         ],
     },
+    'different cases' => {
+        header  => 'Iso-8859-1;q=0.5, Utf-8',
+        values  => [qw/Utf-8 Iso-8859-1/],
+        ok      => [qw/isO-8859-1 utF-8/],
+        nok     => [qw/iso-8859-2/],
+        checks  => [
+            [
+                [qw/iSo-8859-1 uTf-8/],
+                'uTf-8'
+            ],
+            [
+                [qw/isO-8859-1 utF-16/],
+                'isO-8859-1'
+            ],
+            [
+                [qw/IsO-8859-2 UtF-16/],
+                '',
+            ],
+        ],
+    },
     'emtpy string' => {
         header  => '',
         values  => [qw//],
@@ -162,7 +182,7 @@ for my $name ( sort keys %tests ) {
     is $obj->match(), '', "Empty param list ($name)";
 
     for my $ok_check ( @{ $test->{ok} || [] } ) {
-        is $obj->match( $ok_check ), lc $ok_check, "Is: $name -> $ok_check";
+        is $obj->match( $ok_check ), $ok_check, "Is: $name -> $ok_check";
     }
 
     for my $nok_check ( @{ $test->{nok} || [] } ) {


### PR DESCRIPTION
These are likely the list of available charsets, so
not modifying them, while still matching case insensitively would mean we can use the returned value and treat ->match as type of filter.

I don't actually know of any code that needs this, but it seems like from the usage it's picking from a list, so keeping the return value the same as what was passed in seemed like a good idea.

I found this via the pullrequest.club, but without any open issues, figuring out something to add a PR for was interesting.